### PR TITLE
Resolved NullPointerException for proxy settings

### DIFF
--- a/src/main/java/jenkins/plugins/rhnpush/RhnPush.java
+++ b/src/main/java/jenkins/plugins/rhnpush/RhnPush.java
@@ -163,7 +163,7 @@ public class RhnPush extends Recorder {
             } else {
               command.add("--server=" + server, "-u", getUsername(), "-p");
               command.addMasked(getPassword().getPlainText());
-              if(! proxy.isEmpty()) {
+              if(proxy != null && ! proxy.isEmpty()) {
                 command.add("--proxy="+proxy);
               }
             }

--- a/src/main/resources/jenkins/plugins/rhnpush/RhnPush/config.jelly
+++ b/src/main/resources/jenkins/plugins/rhnpush/RhnPush/config.jelly
@@ -16,7 +16,7 @@
     </f:entry>
 
     <f:entry title="${%proxy}" field="proxy">
-      <f:proxy />
+      <f:textbox />
     </f:entry>
 
     <f:entry title="${%username}" field="username">

--- a/src/main/resources/jenkins/plugins/rhnpush/RhnPush/config.properties
+++ b/src/main/resources/jenkins/plugins/rhnpush/RhnPush/config.properties
@@ -1,6 +1,6 @@
 deployEvenBuildFail=Publish even if the build is failed
 server=Satellite server
-proxy=proxy
+proxy=Proxy
 username=Username
 password=Password
 rpmsToPublish=RPMs to publish

--- a/src/main/resources/jenkins/plugins/rhnpush/RhnPush/help-proxy.html
+++ b/src/main/resources/jenkins/plugins/rhnpush/RhnPush/help-proxy.html
@@ -1,1 +1,1 @@
-<div>proxy:port</div>
+<div>The proxy server required to connect to the Satellite server. <br />Format: proxy:port</div>


### PR DESCRIPTION
Due to incorrect Jelly setup the field to enter the proxy settings was
missing. This lead to a NullPointerException when running a build. This
update fixes the issue (shows the field) and ensures null values are
handled properly.
Also updated the help text to be more descriptive.